### PR TITLE
(Re)add package `linux-aarch64-rockchip-opi3b-npu-w568w`

### DIFF
--- a/aarch64.yaml
+++ b/aarch64.yaml
@@ -25,6 +25,10 @@ pkgbuilds:
   linux-aarch64-rockchip-bsp6.1-joshua-git: GH/7Ji-PKGBUILDs/
   linux-aarch64-rockchip-rk3588-bsp5.10-orangepi: GH/7Ji-PKGBUILDs/
   linux-aarch64-rockchip-rk3588-bsp5.10-orangepi-git: GH/7Ji-PKGBUILDs/
+  linux-aarch64-rockchip-opi3b-npu-w568w:
+    url: GITHUB/w568w/alarm_repo
+    branch: main
+    subtree: /
   linux-firmware:
     url: https://gitlab.archlinux.org/archlinux/packaging/packages/linux-firmware.git
     branch: main


### PR DESCRIPTION
See discussions under https://github.com/7Ji/archrepo/commit/612bdef686a7b15335a28b53a5b6addd53b3db0a for more details.

See also: https://github.com/w568w/alarm_repo/commit/3aa3f424aa0bfe0704bf9aca306a3a0955dfab4a.